### PR TITLE
docs: clarify bootstrap prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,29 @@
 Go API service repository for the platform blueprint.
 
 ## Structure
-- `cmd/`: service entrypoints
-- `internal/`: private application code
-- `pkg/`: shareable public packages
-- `deploy/`: deployment manifests and charts
-- `docs/`: service-specific documentation
-- `scripts/`: local utility and developer scripts
+- cmd/: service entrypoints
+- internal/: private application code
+- pkg/: shareable public packages
+- deploy/: deployment manifests and charts
+- docs/: service-specific documentation
+- scripts/: local utility and developer scripts
 
 ## Toolchain
 - GNU Make (or a compatible make implementation)
-- Go `1.24.12`
-- Version pin source: `.tool-versions` and `go.mod`
+- Go 1.24.12
+- Version pin source: .tool-versions and go.mod
 
 ## Setup
-Run one of the following bootstrap commands from the repository root:
-- Make: `make bootstrap`
+Before running bootstrap:
+- Required: GNU Make (or a compatible make implementation)
+- Recommended: mise or sdf for automatic tool installation from .tool-versions
+- Fallback: manually install the pinned tool versions listed above
 
-Bootstrap validates the pinned Go toolchain and runs `go mod download`.
-If `mise` or `asdf` is available, the script will use it to install the pinned toolchain automatically.
+Run the bootstrap command from the repository root:
+- Make: make bootstrap
+
+Bootstrap validates the pinned Go toolchain and runs go mod download.
+If mise or sdf is available, the script will use it to install the pinned toolchain automatically.
 
 ## Run
 No runnable API entrypoint exists yet.
@@ -28,6 +33,4 @@ Service bootstrap and local run commands will be added in later Phase 1 tasks.
 
 ## Test
 No automated test suite is configured yet.
-Linting, formatting, and test commands will be introduced in `P1-T04` and later tasks.
-
-
+Linting, formatting, and test commands will be introduced in P1-T04 and later tasks.


### PR DESCRIPTION
## Summary
- clarify that make is required for bootstrap
- recommend mise or sdf for automatic tool installation
- document manual installation as the fallback path