### PR TITLE
chore: simplify go lint baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,6 @@ format-check: repo-format-check
 
 repo-lint:
 	@if find . -name '*.go' -not -path './vendor/*' | grep -q .; then \
-		unformatted="$$(find . -name '*.go' -not -path './vendor/*' -print0 | xargs -0 gofmt -l)"; \
-		if [[ -n "$$unformatted" ]]; then \
-			echo "The following Go files need formatting:"; \
-			echo "$$unformatted"; \
-			exit 1; \
-		fi; \
-		go vet ./...; \
 		go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run ./...; \
 	else \
 		echo "No Go files yet; skipping Go lint."; \


### PR DESCRIPTION
## Summary
- use golangci-lint as the single Go lint entrypoint
- keep formatting in format and format-check targets
- align repo config with the shared Go lint baseline