### PR TITLE
chore: add local environment contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+APP_ENV=local
+LOG_LEVEL=debug
+HTTP_PORT=8080
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/platform_blueprint?sslmode=disable
+AUTH_ISSUER_URL=https://replace-me.clerk.accounts.dev
+AUTH_AUDIENCE=https://api.local.mpa-forge
+OTEL_MODE=disabled
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_EXPORTER_OTLP_HEADERS=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 bin/
 dist/
 coverage/
+.env
+.env.local
 .DS_Store
 Thumbs.db
 .idea/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ If `mise` or `asdf` is available, the script will use it to install the pinned t
 - Apply formatting: `make format`
 - Check formatting only: `make format-check`
 
+## Environment
+- Copy `.env.example` to `.env` for local development
+- Required local baseline variables:
+  - `APP_ENV`
+  - `LOG_LEVEL`
+  - `HTTP_PORT`
+  - `DATABASE_URL`
+- Planned now and enforced once the runtime exists in Phase 2:
+  - `AUTH_ISSUER_URL`
+  - `AUTH_AUDIENCE`
+  - `OTEL_MODE`
+  - `OTEL_EXPORTER_OTLP_ENDPOINT`
+  - `OTEL_EXPORTER_OTLP_HEADERS`
+
 ## Run
 No runnable API entrypoint exists yet.
 Service bootstrap and local run commands will be added in later Phase 1 tasks.


### PR DESCRIPTION
## Summary
- add .env.example for local development
- document the repo environment contract
- ignore uncommitted local env files