### PR TITLE
chore: add docker baseline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+bin
+dist
+coverage
+docs
+scripts
+.env
+.env.local
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.24.12-alpine AS build
+
+WORKDIR /src
+
+COPY go.mod ./
+RUN go mod download
+
+COPY cmd ./cmd
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/backend-api ./cmd/api-placeholder
+
+FROM alpine:3.22 AS runtime
+
+RUN adduser -D -u 10001 appuser
+
+COPY --from=build /out/backend-api /backend-api
+
+USER appuser
+
+EXPOSE 8080
+
+ENV HTTP_PORT=8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+	CMD wget -q -O /dev/null http://127.0.0.1:8080/healthz || exit 1
+
+ENTRYPOINT ["/backend-api"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ If `mise` or `asdf` is available, the script will use it to install the pinned t
 No runnable API entrypoint exists yet.
 Service bootstrap and local run commands will be added in later Phase 1 tasks.
 
+## Container
+- Build placeholder image: `docker build -t backend-api:local .`
+- The image packages a minimal placeholder HTTP server for the Docker baseline
+- Placeholder routes currently serve `/` and `/healthz` only, pending the real API skeleton in Phase 2
+
 ## Test
 No automated test suite is configured yet.
 Linting, formatting, and test commands will be introduced incrementally in later tasks.

--- a/cmd/api-placeholder/main.go
+++ b/cmd/api-placeholder/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	port := os.Getenv("HTTP_PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = fmt.Fprintln(w, "backend-api placeholder")
+	})
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintln(w, "ok")
+	})
+
+	addr := ":" + port
+	log.Printf("backend-api placeholder listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}


### PR DESCRIPTION
## Summary
- add baseline Dockerfile and dockerignore
- add minimal placeholder runtime assets for image packaging
- document container usage in the README