### PR TITLE
feat: add api local stack wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,13 @@ SHELL := bash
 
 GO_VERSION := 1.24.12
 GOLANGCI_LINT_VERSION := v1.64.8
+PLATFORM_INFRA_DIR := ../platform-infra
+APP_ENV ?= local
+LOG_LEVEL ?= debug
+HTTP_PORT ?= 8080
+DATABASE_URL ?= postgres://postgres:postgres@localhost:5432/platform_blueprint?sslmode=disable
 
-.PHONY: help bootstrap install-tools check-tools print-toolchain install-dev-tools precommit-install precommit-run lint format format-check repo-lint repo-format repo-format-check
+.PHONY: help bootstrap install-tools check-tools print-toolchain install-dev-tools precommit-install precommit-run lint format format-check repo-lint repo-format repo-format-check run support-up support-down support-logs support-ps
 
 help:
 	@echo "Targets:"
@@ -17,6 +22,11 @@ help:
 	@echo "  lint              Run repo lint checks"
 	@echo "  format            Apply repo formatting"
 	@echo "  format-check      Check repo formatting without writing changes"
+	@echo "  run               Run the placeholder API locally on port $(HTTP_PORT)"
+	@echo "  support-up        Start postgres + frontend-web from platform-infra"
+	@echo "  support-down      Stop the shared local compose stack"
+	@echo "  support-logs      Stream postgres + frontend-web logs"
+	@echo "  support-ps        Show shared local compose stack status"
 
 bootstrap: install-tools check-tools install-dev-tools
 	@if find . -name '*.go' -not -path './vendor/*' | grep -q .; then \
@@ -91,3 +101,18 @@ repo-format-check:
 	else \
 		echo "No Go files yet; skipping Go format check."; \
 	fi
+
+run:
+	APP_ENV=$(APP_ENV) LOG_LEVEL=$(LOG_LEVEL) HTTP_PORT=$(HTTP_PORT) DATABASE_URL=$(DATABASE_URL) go run ./cmd/api-placeholder
+
+support-up:
+	$(MAKE) -C $(PLATFORM_INFRA_DIR) local-api-support-up
+
+support-down:
+	$(MAKE) -C $(PLATFORM_INFRA_DIR) local-down
+
+support-logs:
+	$(MAKE) -C $(PLATFORM_INFRA_DIR) local-api-support-logs
+
+support-ps:
+	$(MAKE) -C $(PLATFORM_INFRA_DIR) local-ps

--- a/README.md
+++ b/README.md
@@ -49,13 +49,28 @@ If `mise` or `asdf` is available, the script will use it to install the pinned t
   - `OTEL_EXPORTER_OTLP_HEADERS`
 
 ## Run
-No runnable API entrypoint exists yet.
-Service bootstrap and local run commands will be added in later Phase 1 tasks.
+For native API work:
+
+- Start support services from this repo: `make support-up`
+- Run the API locally: `make run`
+- Stop support services: `make support-down`
+
+The placeholder API serves on `http://localhost:8080`.
+Support services come from the centralized compose stack in `../platform-infra`.
+After code changes, rerun `make run` to restart the native API process.
 
 ## Container
 - Build placeholder image: `docker build -t backend-api:local .`
 - The image packages a minimal placeholder HTTP server for the Docker baseline
 - Placeholder routes currently serve `/` and `/healthz` only, pending the real API skeleton in Phase 2
+
+## Local Stack
+
+- API-focused mode:
+  - run `make support-up`
+  - run `make run`
+  - compose provides `frontend-web` on `http://localhost:3000` and Postgres on `localhost:5432`
+- Frontend-focused mode is orchestrated from `frontend-web`, where compose provides the containerized API on `http://localhost:8080`
 
 ## Test
 No automated test suite is configured yet.


### PR DESCRIPTION
## Summary
- add repo-local wrappers for the centralized compose stack in platform-infra
- add a native placeholder API run command for Phase 1 local development
- document the API-focused local stack flow

## Validation
- docker compose -f ..\\platform-infra\\local\\compose.yml --profile frontend-support up -d --build --remove-orphans
- Invoke-WebRequest http://localhost:8080/healthz
- docker compose -f ..\\platform-infra\\local\\compose.yml --profile frontend-support --profile api-support down --remove-orphans

## Note
- native go run validation remains blocked on this workstation because the Go toolchain is not installed yet