### PR TITLE
docs: clarify supported Windows make setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Go API service repository for the platform blueprint.
 - Go `1.24.12`
 - Version pin source: `.tool-versions` and `go.mod`
 
+Windows note:
+- use a POSIX-friendly GNU Make such as `ezwinports.make` or MSYS2 `make`
+- ensure Git for Windows `bash.exe` is on `PATH`
+- do not use `GnuWin32` make for this repo
+
 ## Setup
 Before running bootstrap:
 - Required: GNU Make (or a compatible `make` implementation) and a bash-compatible shell


### PR DESCRIPTION
## Summary
- document the supported Windows make/bash setup
- clarify that GnuWin32 make should not be used

## Validation
- make check-tools using ezwinports make with Git Bash bash on PATH
- go version resolves to 1.24.12 through the configured mise shim path