### PR TITLE
ci: add reusable workflow entrypoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   ci:
-    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@codex/p4-t01-workflow-rollout
+    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@816e99050519226be282df48aaa86cc9d40227f9
     with:
       working-directory: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: ci
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@main
+    with:
+      working-directory: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   ci:
-    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@816e99050519226be282df48aaa86cc9d40227f9
+    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@main
     with:
       working-directory: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   ci:
-    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@main
+    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@codex/p4-t01-workflow-rollout
     with:
       working-directory: "."


### PR DESCRIPTION
## Summary
- add the repo-local `ci.yml` workflow entrypoint
- call the shared Go reusable workflow from `mpa-forge/.github`
- enable baseline trigger coverage for pull requests, pushes to `main`, and manual dispatch

## Validation
- YAML parsed successfully locally
- `git diff --check` passed