### PR TITLE
ci: wire SonarQube Cloud quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ci:
-    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@main
+    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@4454175b41c288c2fe2052d84889336f3c3591b1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ permissions:
 jobs:
   ci:
     uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@main
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
       working-directory: "."
       sonar-organization-key: "mpa-forge"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,8 @@ permissions:
 jobs:
   ci:
     uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@main
+    secrets: inherit
     with:
       working-directory: "."
+      sonar-organization-key: "mpa-forge"
+      sonar-project-key: "mpa-forge_backend-api"


### PR DESCRIPTION
## Summary`n- pass the SonarQube Cloud organization and project keys into the shared CI workflow`n- inherit secrets so the reusable workflow can read SONAR_TOKEN`n- enable the repo to publish a Sonar quality-gate check from CI