### PR TITLE
Implement API image build and tagging contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,29 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
 
 permissions:
   contents: read
+  id-token: write
   pull-requests: read
 
 jobs:
   ci:
-    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@e7433006b2ffe574d4518f7044e84082bab05e4d
+    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@main
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
       working-directory: "."
       sonar-organization-key: "mpa-forge"
       sonar-project-key: "mpa-forge_backend-api"
+      image-build-enabled: true
+      image-name: "backend-api"
+      image-context: "."
+      image-dockerfile: "Dockerfile"
+      gar-location: ${{ vars.GCP_GAR_LOCATION }}
+      gar-project-id: ${{ vars.GCP_PROJECT_ID }}
+      gar-repository: ${{ vars.GCP_GAR_REPOSITORY_APPS }}
+      gcp-workload-identity-provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      gcp-service-account: ${{ vars.GCP_CI_SERVICE_ACCOUNT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@main
+    uses: mpa-forge/.github/.github/workflows/reusable-ci-go.yml@ced7bfe84128d674daf9b24a5d8cd0a16c979e61
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:

--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ See `docs/database-migrations.md` for details.
 - The image packages the `cmd/api` runtime skeleton
 - Runtime configuration is still supplied through environment variables at container start
 - The container healthcheck follows the configured `HTTP_PORT`
+- CI pull requests now verify the canonical Docker build through the shared Go
+  reusable workflow without publishing a registry artifact
+- CI pushes to `main` and semver tags `v*` now route through the shared Go
+  reusable workflow for `backend-api` image publishing
+- Published image tags follow the shared GAR naming standard:
+  `sha-<git_sha_12>` is always emitted and semver refs additionally publish the
+  matching `v<semver>` alias
+- The shared workflow reads these repository variables when GAR/WIF publishing
+  is configured: `GCP_GAR_LOCATION`, `GCP_PROJECT_ID`,
+  `GCP_GAR_REPOSITORY_APPS`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, and
+  `GCP_CI_SERVICE_ACCOUNT`
+- Until the Phase 4 GAR/WIF bootstrap is in place, the publish job records a
+  skipped publish summary instead of attempting unauthenticated pushes
 
 ## Local Stack
 

--- a/openspec/changes/implement-api-container-build-image-tagging-strategy/.openspec.yaml
+++ b/openspec/changes/implement-api-container-build-image-tagging-strategy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/implement-api-container-build-image-tagging-strategy/design.md
+++ b/openspec/changes/implement-api-container-build-image-tagging-strategy/design.md
@@ -1,0 +1,115 @@
+## Context
+
+`backend-api` currently ships a repo-local Dockerfile and a single reusable CI
+workflow entrypoint, but the repository does not yet define how container
+artifacts are built, tagged, and published for deployment use. Phase 4 task
+P4-T04 requires deterministic API image outputs that align with the shared GAR
+naming convention and support both merge-based traceability and semver-based
+release references.
+
+The design must fit the current repository shape:
+
+- GitHub Actions is the CI entrypoint.
+- The Docker build context is the repository root and packages `cmd/api`.
+- Shared naming guidance requires immutable `sha-<git_sha_12>` tags and allows
+  optional `v<semver>` tags.
+- Follow-on tasks will handle GAR permissions and Workload Identity Federation,
+  so this change should define the publishing contract without assuming static
+  credentials.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define one canonical API image build flow for CI.
+- Make merge builds publish immutable tags that map directly to the source
+  commit.
+- Support semver release tags without changing the underlying image content.
+- Capture enough verification behavior that later implementation can prove tag
+  reproducibility.
+
+**Non-Goals:**
+
+- Building or publishing `backend-worker` images.
+- Redesigning the existing Dockerfile beyond what is required for deterministic
+  CI builds.
+- Finalizing GAR IAM, Workload Identity Federation, or deployment rollout
+  configuration.
+- Adding vulnerability scanning or release orchestration outside image build and
+  tagging behavior.
+
+## Decisions
+
+### Use one canonical Docker build definition
+
+CI will build from the repository root Dockerfile so local and CI image outputs
+stay aligned. This avoids drift between local debugging and merge artifacts and
+keeps the build surface anchored to the existing API packaging path.
+
+Alternative considered: a dedicated CI-only Dockerfile.
+This was rejected because it would duplicate build logic and create avoidable
+divergence between local and CI images.
+
+### Separate verification builds from publish events
+
+Pull requests should prove the Docker build remains healthy, but publishing
+should happen only on merge-oriented events and semver release tags. That keeps
+review workflows safe while still guaranteeing that every merged revision has a
+published immutable image reference.
+
+Alternative considered: publish preview images for every pull request.
+This was rejected for the baseline because it increases registry churn and is
+not required by P4-T04.
+
+### Tag every published image with immutable commit identity first
+
+Every published API image will receive a required `sha-<git_sha_12>` tag. When
+the triggering ref is a semver release tag, CI will additionally publish the
+matching `v<semver>` tag to the same image digest. Deployments and automation
+must treat the SHA tag or digest as canonical, while the semver tag remains a
+human-friendly release alias.
+
+Alternative considered: publishing `latest` or branch-name tags.
+This was rejected because mutable tags weaken traceability and conflict with the
+shared naming standard.
+
+### Verify tag aliasing by digest
+
+When CI emits more than one tag for the same build, the workflow should confirm
+those tags resolve to the same pushed manifest digest. This catches accidental
+double-build drift and preserves the promise that semver tags alias the exact
+immutable merge artifact.
+
+Alternative considered: trust the build-and-push tool without explicit digest
+verification.
+This was rejected because the change goal is reproducible artifacts, not only
+successful pushes.
+
+## Risks / Trade-offs
+
+- [Registry auth is owned by follow-up tasks] -> Keep this change scoped to the
+  publishing contract and implementation hooks, while letting P4-T05/P4-T06
+  provide the final credential path.
+- [Current Dockerfile hardcodes `linux/amd64`] -> Document that platform choice
+  as the initial baseline so later multi-arch work can be an explicit change.
+- [Reusable workflow changes may be needed outside this repo] -> Keep the spec
+  centered on `backend-api` behavior and allow implementation to choose whether
+  repo-local glue or shared workflow updates are the cleanest delivery path.
+
+## Migration Plan
+
+1. Extend the merge pipeline so `main` pushes build and publish the API image.
+2. Add semver-tag handling that reuses the same build/tag logic.
+3. Expose the published image URI and digest in workflow logs or outputs for
+   downstream deployment consumers.
+4. Validate that the merge and release tags resolve to the expected digest
+   before making the workflow the canonical publish path.
+
+Rollback is straightforward: disable the publish step while retaining the
+non-publishing build verification job.
+
+## Open Questions
+
+None. The first implementation will extend the shared reusable workflow path
+used by `backend-api`, and the rollout will stay minimal by deferring optional
+OCI metadata labels until a follow-up change requires them.

--- a/openspec/changes/implement-api-container-build-image-tagging-strategy/proposal.md
+++ b/openspec/changes/implement-api-container-build-image-tagging-strategy/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The API repository already defines a runnable container image, but Phase 4
+still lacks a committed CI contract for building and publishing that image with
+deterministic tags. We need that contract now so merges can produce traceable
+artifacts that downstream deployment automation can consume without relying on
+mutable tags or ad hoc build behavior.
+
+## What Changes
+
+- Define the `backend-api` image publishing contract for merge pipelines.
+- Require immutable commit-based image tags and optional semver-aligned release
+  tags that follow the shared platform naming standard.
+- Document the CI build inputs, tag calculation rules, and publication outputs
+  needed for reproducible API image artifacts.
+- Establish the baseline verification steps that confirm published tags point to
+  the same built image content.
+
+## Capabilities
+
+### New Capabilities
+
+- `api-image-publishing`: Defines how `backend-api` container images are built,
+  tagged, and published from CI with immutable and release-friendly tags.
+
+### Modified Capabilities
+
+## Impact
+
+- `backend-api` GitHub Actions workflows and supporting CI scripts
+- Container build inputs such as the repo Dockerfile and build context
+- Image consumers in deployment automation that must reference immutable tags
+- Shared GAR naming and release-tag expectations used across the platform

--- a/openspec/changes/implement-api-container-build-image-tagging-strategy/specs/api-image-publishing/spec.md
+++ b/openspec/changes/implement-api-container-build-image-tagging-strategy/specs/api-image-publishing/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Pull requests verify the canonical API container build
+
+The `backend-api` repository SHALL run a container build verification step in
+CI for pull requests using the repository-root Dockerfile and build context that
+package `cmd/api`.
+
+#### Scenario: Pull request validates the API image build
+
+- **WHEN** a pull request triggers the repository CI workflow
+- **THEN** CI builds the API container image from the canonical Dockerfile
+- **AND** the build completes without publishing a registry tag
+
+### Requirement: Merge builds publish immutable API image tags
+
+The `backend-api` merge pipeline SHALL publish the API container image to the
+configured GAR repository using the shared naming pattern
+`${REGION}-docker.pkg.dev/${PROJECT_ID}/${GAR_REPOSITORY}/backend-api:${TAG}`,
+and every published merge artifact MUST include an immutable
+`sha-<git_sha_12>` tag derived from the source commit. The pipeline MUST NOT
+publish a mutable `latest` tag for deployment use.
+
+#### Scenario: Main merge publishes a deterministic SHA tag
+
+- **WHEN** code is merged and the publish pipeline runs for the resulting
+  commit
+- **THEN** the API image is pushed with the tag `sha-<git_sha_12>` for that
+  commit
+- **AND** no `latest` deployment tag is emitted
+
+### Requirement: Release tags alias the immutable merge artifact
+
+The publish pipeline SHALL, when running for a semver Git ref named
+`v<semver>`, publish the matching semver tag in addition to the required
+immutable SHA tag, and both tags MUST reference the same pushed image digest.
+
+#### Scenario: Semver release publishes a release alias
+
+- **WHEN** CI runs for a Git tag that matches `v<semver>`
+- **THEN** the API image is published with both `sha-<git_sha_12>` and
+  `v<semver>` tags
+- **AND** the published tags resolve to the same image digest
+
+### Requirement: Published image metadata is traceable in CI output
+
+The publish workflow SHALL expose the final published image reference and digest
+in CI output so downstream automation and operators can map a merge or release
+event to the exact container artifact.
+
+#### Scenario: Publish job reports the pushed artifact identity
+
+- **WHEN** the publish workflow completes successfully
+- **THEN** the job output or logs include the published `backend-api` image URI
+- **AND** the output includes the pushed manifest digest for that artifact

--- a/openspec/changes/implement-api-container-build-image-tagging-strategy/tasks.md
+++ b/openspec/changes/implement-api-container-build-image-tagging-strategy/tasks.md
@@ -1,0 +1,27 @@
+## 1. Establish the image publish workflow contract
+
+- [x] 1.1 Inspect the current `backend-api` CI workflow and decide whether the
+  image build logic should live in this repo or in the shared reusable workflow
+  layer.
+- [x] 1.2 Add CI logic that builds the canonical API Docker image on pull
+  requests without publishing it.
+- [x] 1.3 Add merge and semver-trigger handling that computes the required
+  `sha-<git_sha_12>` tag and optional `v<semver>` tag for `backend-api`.
+
+## 2. Publish deterministic API image artifacts
+
+- [x] 2.1 Configure the publish job to push `backend-api` images to the
+  platform GAR path using the shared naming convention and without emitting a
+  `latest` tag.
+- [x] 2.2 Add workflow verification that semver and SHA tags point to the same
+  pushed image digest when both tags are published.
+- [x] 2.3 Expose the final published image URI and digest in workflow outputs or
+  logs for downstream deployment traceability.
+
+## 3. Validate and document the rollout
+
+- [x] 3.1 Update repo-facing CI or container documentation to describe the
+  canonical image tags and publish behavior for `backend-api`.
+- [x] 3.2 Run the repo validation needed for the workflow changes and capture
+  any follow-up dependency on GAR auth or WIF setup required by later Phase 4
+  tasks.


### PR DESCRIPTION
## Summary
- wire `backend-api` CI into the shared API image build/publish flow
- add the OpenSpec change artifacts for the image publishing contract
- document the repo-level tag, publish, and pending GAR/WIF configuration behavior

## Validation
- `openspec validate implement-api-container-build-image-tagging-strategy`
- YAML parse check for updated workflow files
- repo pre-commit hooks during commit (`check yaml`, `yamllint`, `markdownlint-cli2`, `repo lint`, `repo format check`)