### PR TITLE
Clarify split database config precedence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@ APP_ENV=local
 LOG_LEVEL=debug
 HTTP_PORT=8080
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/platform_blueprint?sslmode=disable
-# Cloud runtimes may omit DATABASE_URL and provide split database values instead.
+# Local development can keep DATABASE_URL. Cloud runtimes should leave it blank.
+# Provide DB_HOST, DB_NAME, DB_USER, and secret-backed DB_PASSWORD instead.
 # DB_HOST accepts either host[:port] or a Cloud SQL socket path such as /cloudsql/project:region:instance.
 DB_HOST=
 DB_NAME=

--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ If `mise` or `asdf` is available, the script will use it to install the pinned t
 The API runtime now validates all of the variables above at startup and exits
 before binding a port when required values are missing or malformed.
 For local development, `DATABASE_URL` remains the shortest supported database
-configuration. Cloud runtimes can omit `DATABASE_URL` and provide `DB_HOST`,
-`DB_NAME`, `DB_USER`, and secret-backed `DB_PASSWORD`; `DB_HOST` accepts either
-`host[:port]` or a Cloud SQL socket path such as `/cloudsql/project:region:instance`.
+configuration. Cloud runtimes should leave `DATABASE_URL` unset and provide
+`DB_HOST`, `DB_NAME`, `DB_USER`, and secret-backed `DB_PASSWORD`; when those
+split values are present they take precedence so the runtime composes the final
+Postgres URL itself. `DB_HOST` accepts either `host[:port]` or a Cloud SQL
+socket path such as `/cloudsql/project:region:instance`.
 See `docs/api-runtime.md` for endpoint and runtime details and
 `docs/auth-implementation.md` for the auth enforcement internals.
 See `docs/api-alerting.md` for the Phase 3 backend-api alert contract and rule
@@ -135,7 +137,9 @@ Typical local flow:
 See `docs/database-migrations.md` for details.
 Migration commands use the same database configuration contract as the runtime:
 `DATABASE_URL` for local compatibility, or split `DB_HOST`, `DB_NAME`,
-`DB_USER`, and `DB_PASSWORD` values for Cloud SQL-oriented execution.
+`DB_USER`, and `DB_PASSWORD` values for Cloud SQL-oriented execution; cloud
+delivery keeps the password in `DB_PASSWORD` instead of a canonical
+`DATABASE_URL` secret.
 
 ## Container
 

--- a/docs/api-runtime.md
+++ b/docs/api-runtime.md
@@ -31,8 +31,9 @@ live in `openspec/specs/api-runtime/spec.md`.
   - `GRAFANA_CLOUD_INSTANCE_ID`
   - `GRAFANA_OTLP_INGEST_TOKEN`
 - database configuration accepts either local `DATABASE_URL` or split
-  `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASSWORD`; `DB_HOST` may be a
-  Cloud SQL socket path under `/cloudsql`
+  `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASSWORD`; cloud runtimes should
+  leave `DATABASE_URL` unset and the split contract wins whenever those values
+  are populated; `DB_HOST` may be a Cloud SQL socket path under `/cloudsql`
 - the runtime composes the OTLP Basic auth header from the Grafana instance ID
   and ingest token instead of requiring `OTEL_EXPORTER_OTLP_HEADERS`
 - `make run` sources `.env` when present and starts `./cmd/api`

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -18,8 +18,9 @@ persistence requirements now live in
   - `make sqlc-generate`
 - migration, seed, query, generated sqlc, and migrate entrypoint assets remain
   under `internal/database/` and `cmd/migrate/`
-- migration commands select the target database from `DATABASE_URL` when set,
-  or from split `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASSWORD` values
+- migration commands select the target database from local `DATABASE_URL` when
+  no split database inputs are configured, or from split `DB_HOST`, `DB_NAME`,
+  `DB_USER`, and `DB_PASSWORD` values when the cloud-runtime contract is used
 - the baseline schema includes `user_profiles`
 - `user_profiles.clerk_user_id` remains the canonical persistence key for the
   verified Clerk `sub`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,10 +93,11 @@ func LoadFromEnv() (Config, error) {
 }
 
 // LoadDatabaseURLFromEnv returns the Postgres connection string accepted by
-// runtime and migration commands. DATABASE_URL remains supported for local
-// compatibility; cloud runtimes can instead provide split DB_* values.
+// runtime and migration commands. Local workflows can keep using DATABASE_URL.
+// Cloud runtimes should provide the split DB_* contract, which takes priority
+// whenever any non-empty split value is configured.
 func LoadDatabaseURLFromEnv(problems *[]string) string {
-	if databaseURL := strings.TrimSpace(os.Getenv("DATABASE_URL")); databaseURL != "" {
+	if databaseURL := strings.TrimSpace(os.Getenv("DATABASE_URL")); databaseURL != "" && !hasConfiguredSplitDatabaseEnv() {
 		if parseAbsoluteURL("DATABASE_URL", databaseURL, problems) == nil {
 			return ""
 		}
@@ -104,6 +105,20 @@ func LoadDatabaseURLFromEnv(problems *[]string) string {
 		return databaseURL
 	}
 
+	return loadSplitDatabaseURL(problems)
+}
+
+func hasConfiguredSplitDatabaseEnv() bool {
+	for _, key := range []string{"DB_HOST", "DB_NAME", "DB_USER", "DB_PASSWORD"} {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func loadSplitDatabaseURL(problems *[]string) string {
 	dbHost := requireNonEmptyEnv("DB_HOST", problems)
 	dbName := requireNonEmptyEnv("DB_NAME", problems)
 	dbUser := requireNonEmptyEnv("DB_USER", problems)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -113,7 +113,26 @@ func TestLoadFromEnvComposesDatabaseURLFromCloudSQLSocket(t *testing.T) {
 	}
 }
 
-func TestLoadDatabaseURLFromEnvPrefersDatabaseURL(t *testing.T) {
+func TestLoadDatabaseURLFromEnvUsesDatabaseURLWhenSplitValuesAreBlank(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/platform_blueprint?sslmode=disable")
+	t.Setenv("DB_HOST", "")
+	t.Setenv("DB_NAME", "")
+	t.Setenv("DB_USER", "")
+	t.Setenv("DB_PASSWORD", "")
+
+	var problems []string
+	databaseURL := LoadDatabaseURLFromEnv(&problems)
+	if len(problems) > 0 {
+		t.Fatalf("LoadDatabaseURLFromEnv() problems = %v, want none", problems)
+	}
+
+	want := "postgres://postgres:postgres@localhost:5432/platform_blueprint?sslmode=disable"
+	if databaseURL != want {
+		t.Fatalf("LoadDatabaseURLFromEnv() = %q, want %q", databaseURL, want)
+	}
+}
+
+func TestLoadDatabaseURLFromEnvPrefersSplitValuesWhenConfigured(t *testing.T) {
 	t.Setenv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/platform_blueprint?sslmode=disable")
 	t.Setenv("DB_HOST", "/cloudsql/example-project:europe-west1:platform-rc-db")
 	t.Setenv("DB_NAME", "platform_rc")
@@ -126,7 +145,26 @@ func TestLoadDatabaseURLFromEnvPrefersDatabaseURL(t *testing.T) {
 		t.Fatalf("LoadDatabaseURLFromEnv() problems = %v, want none", problems)
 	}
 
-	want := "postgres://postgres:postgres@localhost:5432/platform_blueprint?sslmode=disable"
+	want := "postgres://api_user:secret@/platform_rc?host=%2Fcloudsql%2Fexample-project%3Aeurope-west1%3Aplatform-rc-db&sslmode=disable"
+	if databaseURL != want {
+		t.Fatalf("LoadDatabaseURLFromEnv() = %q, want %q", databaseURL, want)
+	}
+}
+
+func TestLoadDatabaseURLFromEnvIgnoresInvalidDatabaseURLWhenSplitValuesAreConfigured(t *testing.T) {
+	t.Setenv("DATABASE_URL", "not-a-url")
+	t.Setenv("DB_HOST", "10.10.0.4:5432")
+	t.Setenv("DB_NAME", "platform_rc")
+	t.Setenv("DB_USER", "api_user")
+	t.Setenv("DB_PASSWORD", "secret")
+
+	var problems []string
+	databaseURL := LoadDatabaseURLFromEnv(&problems)
+	if len(problems) > 0 {
+		t.Fatalf("LoadDatabaseURLFromEnv() problems = %v, want none", problems)
+	}
+
+	want := "postgres://api_user:secret@10.10.0.4:5432/platform_rc?sslmode=disable"
 	if databaseURL != want {
 		t.Fatalf("LoadDatabaseURLFromEnv() = %q, want %q", databaseURL, want)
 	}

--- a/openspec/specs/api-runtime/spec.md
+++ b/openspec/specs/api-runtime/spec.md
@@ -11,10 +11,14 @@ validation, local run behavior, and the mounted public and Connect endpoints.
 
 The `backend-api` runtime SHALL validate its required startup configuration
 before binding an HTTP port. Required variables MUST include `APP_ENV`,
-`LOG_LEVEL`, `HTTP_PORT`, `DATABASE_URL`, `AUTH_ISSUER_URL`,
-`AUTH_AUDIENCE`, `OTEL_MODE`, `OBS_TELEMETRY_PROFILE`,
+`LOG_LEVEL`, `HTTP_PORT`, `AUTH_ISSUER_URL`, `AUTH_AUDIENCE`, `OTEL_MODE`,
+`OBS_TELEMETRY_PROFILE`,
 `OTEL_EXPORTER_OTLP_ENDPOINT`, `GRAFANA_CLOUD_INSTANCE_ID`, and
-`GRAFANA_OTLP_INGEST_TOKEN`.
+`GRAFANA_OTLP_INGEST_TOKEN`. Database configuration MUST accept either local
+`DATABASE_URL` or the split contract `DB_HOST`, `DB_NAME`, `DB_USER`, and
+`DB_PASSWORD`. When split database values are populated, the runtime MUST
+compose the final Postgres URL from those values instead of expecting a
+canonical `DATABASE_URL` secret.
 `OTEL_MODE` MUST accept only `disabled`, `direct_otlp`, or
 `collector_gateway`. `OBS_TELEMETRY_PROFILE` MUST accept only `balanced`,
 `cost`, or `debug`, and it MUST default to `balanced` when unset.
@@ -24,8 +28,15 @@ the OTLP endpoint and Grafana OTLP token ingredients MUST be present and valid.
 #### Scenario: Startup fails on missing required configuration
 
 - **WHEN** the API process starts without one of the required environment
-  variables
+  variables or without either supported database configuration form
 - **THEN** the runtime exits before binding the configured HTTP port
+
+#### Scenario: Split database inputs override a local database URL fallback
+
+- **WHEN** cloud runtime delivery populates `DB_HOST`, `DB_NAME`, `DB_USER`,
+  and `DB_PASSWORD`
+- **THEN** the runtime composes the database connection string from those
+  values and does not require a canonical `DATABASE_URL` secret
 
 #### Scenario: Telemetry configuration is required when enabled
 

--- a/openspec/specs/database-migration-baseline/spec.md
+++ b/openspec/specs/database-migration-baseline/spec.md
@@ -13,13 +13,15 @@ and the `user_profiles` identity contract.
 The repository SHALL provide repo-local database lifecycle commands for the API
 service. At minimum, `make migrate-up`, `make migrate-down`, `make db-seed`,
 `make db-prepare`, and `make sqlc-generate` MUST be available from the
-repository root when `DATABASE_URL` is configured.
+repository root when either local `DATABASE_URL` or split `DB_HOST`, `DB_NAME`,
+`DB_USER`, and `DB_PASSWORD` inputs are configured.
 
 #### Scenario: Operators can apply the schema baseline
 
 - **WHEN** an operator runs `make migrate-up`
 - **THEN** the repository applies the embedded Postgres schema migrations using
-  the configured `DATABASE_URL`
+  the resolved database URL from either local `DATABASE_URL` or the split
+  cloud-runtime database contract
 
 #### Scenario: Developers can prepare a local database baseline
 


### PR DESCRIPTION
Clarifies and hardens the Phase 5 split database configuration contract.

- prefer split `DB_*` values whenever any cloud-runtime database input is configured
- keep local `DATABASE_URL` support when split values are blank
- document the precedence rules in runtime and migration docs
- update OpenSpec requirements and tests to cover the precedence behavior
